### PR TITLE
Schema change (products and payouts)-- add default_price and reconciliation_status dimension

### DIFF
--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -205,6 +205,12 @@
         "string"
       ],
       "format": "date-time"
+    },
+    "payment_intent": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tap_stripe/schemas/disputes.json
+++ b/tap_stripe/schemas/disputes.json
@@ -205,12 +205,6 @@
         "string"
       ],
       "format": "date-time"
-    },
-    "payment_intent": {
-      "type": [
-        "null",
-        "string"
-      ]
     }
   }
 }

--- a/tap_stripe/schemas/payouts.json
+++ b/tap_stripe/schemas/payouts.json
@@ -7,6 +7,12 @@
       ],
       "properties": {}
     },
+    "reconciliation_status": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "failure_code": {
       "type": [
         "null",

--- a/tap_stripe/schemas/products.json
+++ b/tap_stripe/schemas/products.json
@@ -176,6 +176,12 @@
         "null",
         "string"
       ]
+    },
+    "default_price": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }


### PR DESCRIPTION
# Description of change

As seen here (https://stripe.com/docs/api/products), default_price is missing from products schema. 
As seen here (https://stripe.com/docs/api/payouts), reconciliation_status is missing from payouts schema. 

Adding this field.

# Manual QA steps
 - Run within your local dev to see changes if you have data for products and payouts.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
