### PR TITLE
Schema change (subscription)-- add 7 missing dimensions (automatic_tax, cancellation_details, currency, description, default_tax_rates,  pending_update and trial_settings)

### DIFF
--- a/sample_config.json
+++ b/sample_config.json
@@ -1,4 +1,5 @@
 {
-  "client_secret": "<stripe_platform_client_secret>",
-  "account_id": "<stripe_account_id>"
+  "client_secret": "",
+  "account_id": "",
+  "start_date": ""
 }

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -489,6 +489,52 @@
         "string"
       ],
       "format": "date-time"
-    }
+    },
+    "description": {
+      "type": [
+         "null",
+         "string"
+      ]
+    },
+    "automatic_tax":{
+      "type": [
+         "null",
+         "object"
+      ],
+      "properties": {
+         "enabled": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        }
+      }
+    },
+    "cancellation_details":{
+      "type":[
+         "null",
+         "object"
+      ],
+      "properties":{
+         "comment":{
+            "type":[
+               "null",
+               "string"
+            ]
+         },
+         "feedback":{
+            "type":[
+               "null",
+               "string"
+            ]
+         },
+         "reason":{
+            "type":[
+               "null",
+               "string"
+            ]
+         }
+      }
+   }
   }
 }

--- a/tap_stripe/schemas/subscriptions.json
+++ b/tap_stripe/schemas/subscriptions.json
@@ -535,6 +535,152 @@
             ]
          }
       }
-   }
+   },
+   "default_tax_rates": {
+    "type": [
+      "null",
+      "array"
+    ],
+    "items": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ] 
+        },
+        "active": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "country": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "display_name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "effecive_percentage": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "inclusive": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "jurisdiction": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "percentage": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "singer.decimal"
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "tax_type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  },
+  "currency": {
+    "type": [
+      "null",
+      "string"
+    ]
+  },
+   "trial_settings": {
+    "type":[
+       "null",
+       "object"
+    ],
+      "properties": {
+        "end_behavior": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "missing_payment_method": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "enum": ["cancel", "pause", "create_invoice"]
+            }
+          }
+        }
+      }
+    },
+   "pending_update":{
+    "type":[
+       "null",
+       "object"
+    ],
+    "properties": {
+       "billing_cycle_anchor":{
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+       },
+       "expires_at":{
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+       },
+       "trial_end":{
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+       },
+       "trial_from_plan":{
+        "type":[
+           "null",
+           "boolean"
+        ]
+      }       
+    }
   }
+}
 }


### PR DESCRIPTION
# Description of change

As seen here (https://stripe.com/docs/api/subscriptions/object), automatic_tax, cancellation_details, currency, description, default_tax_rates,  pending_update and trial_settings is missing from subscriptions schema. 

These changes add them in. 

Adding this field.

# Manual QA steps
 - Run within your local dev to see changes if you have data for the fields for subscriptions.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
