### PR TITLE
Schema Change (Invoices) - Add 7 fields (application, shipping_d…

### DIFF
--- a/tap_stripe/schemas/invoices.json
+++ b/tap_stripe/schemas/invoices.json
@@ -955,6 +955,121 @@
       ],
       "properties": {}
     },
+    "shipping_details": {
+      "type":[
+         "null",
+         "object"
+      ],
+        "properties": {
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "phone": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "address": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "city": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "country": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "line1": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "line2": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "postal_code": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "state": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              }
+            }
+          }
+        }
+      },
+      "amount_shipping": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "applicaton": {
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      "from_invoice": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "action": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "invoice": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      },
+      "subtotal_excluding_tax": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "total_excluding_tax": {
+        "type": [
+          "null",
+          "integer"
+        ]
+      },
+      "effective_at": {
+        "type": [
+          "null",
+          "string"
+        ],
+        "format": "date-time"
+      },
     "updated": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change

As seen here (https://stripe.com/docs/api/invoices/object), 7 fields (application, shipping_details, amount_shipping, effective_at, from_invoice, subtotal_excluding_tax, total_excluding_tax) are missing from invoices schema.

Added to schema.

Adding this field.

# Manual QA steps
 - Run within your local dev to see changes if you have data for products and payouts.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
