### PR TITLE
Schema Change (Invoice Line Item) - amount_excluding tax, unit_amount_excluding_tax 

### DIFF
--- a/tap_stripe/schemas/invoice_line_items.json
+++ b/tap_stripe/schemas/invoice_line_items.json
@@ -147,12 +147,6 @@
         "boolean"
       ]
     },
-    "proration_details": {
-      "type": [
-        "null",
-        "object"
-      ]
-    },
     "period": {
       "type": [
         "null",
@@ -499,6 +493,47 @@
         "null",
         "string"
       ]
-    }
+    },
+    "unit_amount_excluding_tax": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "singer.decimal"
+    },
+    "amount_excluding_tax": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "proration_details": {
+      "type":[
+         "null",
+         "object"
+      ],
+        "properties": {
+          "credited_items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "properties": {
+              "invoice": {
+                "type": [
+                  "null",
+                  "string"
+                ]
+              },
+              "invoice_line_items": {
+                "type": [
+                  "null",
+                  "array"
+                ]
+              }
+            }
+          }
+        }
+      }    
   }
 }


### PR DESCRIPTION
# Description of change

As seen here (https://stripe.com/docs/api/invoices/line_item), added amount_excluding tax and unit_amount_excluding_tax to schema, as well as expanded the proration_details field.

Added to schema.

# Manual QA steps
 - Run within your local dev to see changes if you have data for products and payouts.
 
# Risks
 - Limited as API documentation lists field.
 
# Rollback steps
 - revert this branch
